### PR TITLE
Tweaks

### DIFF
--- a/draft-rosomakho-httpbis-h3-unbound-data.md
+++ b/draft-rosomakho-httpbis-h3-unbound-data.md
@@ -81,7 +81,7 @@ The `SETTINGS_ENABLE_UNBOUND_DATA` parameter is directional: each endpoint indep
 
 # UNBOUND_DATA Frame
 
-The `UNBOUND_DATA` frame (type=0x2a937388) is used on request or response streams to indicate that all subsequent octets on the stream are interpreted as data. This data can represent an HTTP message body or the data stream (as defined in {{Section 3.1 of !HTTP-DGRAM=RFC9297}}).
+The `UNBOUND_DATA` frame (type=0x2a937388) is used on request or response streams to indicate that all subsequent octets on the stream are interpreted as data. This data can represent an HTTP message body or the data stream as defined in {{Section 3.1 of !HTTP-DGRAM=RFC9297}}.
 
 ## Frame Layout
 

--- a/draft-rosomakho-httpbis-h3-unbound-data.md
+++ b/draft-rosomakho-httpbis-h3-unbound-data.md
@@ -38,7 +38,7 @@ informative:
 
 --- abstract
 
-This document defines a new HTTP/3 frame type, `UNBOUND_DATA`, and a corresponding `SETTINGS` parameter that enables endpoints to negotiate its use. When an endpoint sends an `UNBOUND_DATA` frame on a request or response stream, it indicates that all subsequent octets on that stream are interpreted as data. This applies both to message body data and to octets transmitted after CONNECT or extended CONNECT. The use of `UNBOUND_DATA` removes the need to encapsulate each portion of the data in `DATA` frames, reducing framing overhead and simplifying transmission of long-lived or indeterminate-length payloads. The use of `UNBOUND_DATA` is disallowed when a `Content-Length` header is present or when trailers are required.
+This document defines a new HTTP/3 frame type, `UNBOUND_DATA`, and a corresponding `SETTINGS` parameter that enables endpoints to negotiate its use. When an endpoint sends an `UNBOUND_DATA` frame on a request or response stream, it indicates that all subsequent octets on that stream are interpreted as data. This applies both to message body data and to octets transmitted after CONNECT or extended CONNECT. The use of `UNBOUND_DATA` removes the need to encapsulate each portion of the data in `DATA` frames, reducing framing overhead and simplifying transmission of long-lived or indeterminate-length payloads.
 
 --- middle
 
@@ -64,7 +64,7 @@ The use of UNBOUND_DATA does not alter HTTP semantics, flow control, or prioriti
 
 # Capability Negotiation
 
-Endpoints indicate support for unbound data transmission by sending the `SETTINGS_ENABLE_UNBOUND_DATA` (0xTBD) setting with a value of 1.
+Endpoints indicate support for unbound data transmission by sending the `SETTINGS_ENABLE_UNBOUND_DATA` (0x282cf6bb) setting with a value of 1.
 
 The valid values of the `SETTINGS_ENABLE_UNBOUND_DATA` setting are 0 and 1. If the `SETTINGS_ENABLE_UNBOUND_DATA` setting is received with a different value, the receiver MUST treat it as a connection error of type `H3_SETTINGS_ERROR`.
 
@@ -73,17 +73,16 @@ A value of 1 indicates that the sender of the SETTINGS frame is willing to recei
 Endpoints MUST NOT send an `UNBOUND_DATA` frame to a peer that has not advertised `SETTINGS_ENABLE_UNBOUND_DATA` with a value of 1. Endpoints that receive an `UNBOUND_DATA` frame without having advertised support MUST treat it as a connection error of type `H3_FRAME_UNEXPECTED`.
 
 The `SETTINGS_ENABLE_UNBOUND_DATA` parameter is directional: each endpoint independently advertises whether it accepts receiving `UNBOUND_DATA`. An endpoint that has not indicated support cannot be assumed to understand or correctly process the frame.
-If multiple instances of `SETTINGS_ENABLE_UNBOUND_DATA` are received, the last value applies as specified in {{Section 7.2.4 of H3}}.
 
 # UNBOUND_DATA Frame
 
-The `UNBOUND_DATA` frame (type=0xTBD1) is used on request or response streams to indicate that all subsequent octets on the stream are interpreted as data. This data can represent an HTTP message body or the opaque octets transmitted after a CONNECT or extended CONNECT.
+The `UNBOUND_DATA` frame (type=0x2a937388) is used on request or response streams to indicate that all subsequent octets on the stream are interpreted as data. This data can represent an HTTP message body or the data stream (as defined in {{Section 3.1 of !HTTP-DGRAM=RFC9297}}).
 
 ## Frame Layout
 
 ~~~
 UNBOUND_DATA Frame {
-  Type (i) = 0xTBD1,
+  Type (i) = 0x2a937388,
   Length (8) = 0,
 }
 ~~~
@@ -96,8 +95,9 @@ The `UNBOUND_DATA` frame has no payload. The Length field of the frame MUST be z
 Upon receiving an `UNBOUND_DATA` frame on a request or response stream, the receiver enters unbound mode for that stream. In unbound mode:
 
 - All remaining octets on the stream, up to the QUIC FIN, are interpreted as data.
-- No further HTTP/3 frames (including `DATA`, `HEADERS`, or any extension frames) cam be received on the stream.
+- No further HTTP/3 frames (including `DATA`, `HEADERS`, or any extension frames) can be received on the stream.
 - The end of the data is indicated by the QUIC FIN on the stream.
+- If a `Content-Length` header was included, the recipient needs to ensure that the combined length of all received data (in both `DATA` and `UNBOUND_DATA` frames) matches the content length from the header.
 
 ## Restrictions
 
@@ -106,13 +106,12 @@ The use of `UNBOUND_DATA` is subject to the following restrictions:
 - An endpoint MUST NOT send `UNBOUND_DATA` if it previously sent a `HEADERS` frame with a `Content-Length` header field.
 - `UNBOUND_DATA` frame is only valid on request or response streams. It is invalid on control streams, QPACK encoder/decoder streams, or push streams.
 - `UNBOUND_DATA` MUST NOT be sent to peers that have not advertised `SETTINGS_ENABLE_UNBOUND_DATA` with a value of 1.
-- `UNBOUND_DATA` MUST NOT be sent before the initial `HEADERS` that start the message.
 
 Any violation of these restrictions MUST be treated as a connection error of type `H3_FRAME_UNEXPECTED`.
 
 # Stream State Transitions
 
-The use of the `UNBOUND_DATA` frame modifies the sequence of frames permitted on request and response streams.
+The use of the `UNBOUND_DATA` frame modifies the sequence of frames exchanged on request and response streams.
 
 In normal operation, a request or response body is carried as a sequence of one or more `DATA` frames, followed optionally by a `HEADERS` frame containing trailers:
 
@@ -127,7 +126,7 @@ In normal operation, a request or response body is carried as a sequence of one 
 ~~~
 {: #fig-regular-http3-state title="Regular HTTP/3 Frame sequence on bi-directional stream"}
 
-When `UNBOUND_DATA` is used, the sender signals that all subsequent octets on the stream are data. Regular `DATA` frames MAY be sent on a stream prior to the `UNBOUND_DATA`. After the `UNBOUND_DATA` frame, the sender MUST NOT send any further HTTP/3 frames on the stream. The end of the body is signaled by the QUIC stream FIN:
+When `UNBOUND_DATA` is used, the sender signals that all subsequent octets on the stream are data. Regular `DATA` frames MAY be sent on a stream prior to the `UNBOUND_DATA`. After the `UNBOUND_DATA` frame, the sender cannot send any further HTTP/3 frames on the stream. The end of the body is signaled by the QUIC stream FIN:
 
 ~~~aasvg
   New bi-directional QUIC stream ---->  +------------------------+
@@ -142,6 +141,8 @@ When `UNBOUND_DATA` is used, the sender signals that all subsequent octets on th
 ~~~
 {: #fig-regular-http3-unbound-state title="HTTP/3 Frame sequence with UNBOUND_DATA"}
 
+Since the recipient of an `UNBOUND_DATA` will no longer parse frame types on the stream after its receipt, it is not possible to send other frames after the `UNBOUND_DATA`. If that is required, for example if the sender wishes to send trailers, then the `UNBOUND_DATA` frame cannot be used.
+
 # Security Considerations
 
 The introduction of `UNBOUND_DATA` does not alter the security properties of HTTP/3 or QUIC. It only changes how message bodies or tunneled octets are framed on request and response streams.
@@ -152,7 +153,7 @@ The introduction of `UNBOUND_DATA` does not alter the security properties of HTT
 
 This specification registers the following entry in the "HTTP/3 Settings" registry defined in {{H3}}:
 
-- Code: 0xTBD
+- Code: 0x282cf6bb
 - Setting Name: SETTINGS_ENABLE_UNBOUND_DATA
 - Default: 0
 - Status: provisional (permanent if this document is approved)
@@ -165,7 +166,7 @@ This specification registers the following entry in the "HTTP/3 Settings" regist
 
 This specification registers the following entry in the "HTTP/3 Frame Types" registry defined in {{H3}}:
 
-- Value: 0xTBD1
+- Value: 0x2a937388
 - Frame Type: UNBOUND_DATA
 - Status: provisional (permanent if this document is approved)
 - Reference: This document

--- a/draft-rosomakho-httpbis-h3-unbound-data.md
+++ b/draft-rosomakho-httpbis-h3-unbound-data.md
@@ -28,6 +28,11 @@ author:
     fullname: Yaroslav Rosomakho
     organization: Zscaler
     email: yrosomakho@zscaler.com
+ -
+    ins: D. Schinazi
+    name: David Schinazi
+    organization: Google LLC
+    email: dschinazi.ietf@gmail.com
 
 normative:
   H3:

--- a/draft-rosomakho-httpbis-h3-unbound-data.md
+++ b/draft-rosomakho-httpbis-h3-unbound-data.md
@@ -95,6 +95,10 @@ UNBOUND_DATA Frame {
 
 The `UNBOUND_DATA` frame has no payload. The Length field of the frame MUST be zero. If a nonzero length is received, the endpoint MUST treat this as a connection error of type `H3_FRAME_ERROR`.
 
+The `UNBOUND_DATA` frame is only valid on request or response streams. It is invalid on control streams, QPACK encoder/decoder streams, or push streams. If an endpoint receives an `UNBOUND_DATA` frame on a stream that isn't a client-initiated bidirectional stream, it MUST treat it as a connection error of type `H3_FRAME_UNEXPECTED`.
+
+Similar to `DATA` frames, endpoints MUST sent a `HEADERS` frame before sending an `UNBOUND_DATA` frame on a given stream. Receipt of an `UNBOUND_DATA` frame on a stream that hasn't received a `HEADERS` frame MUST be treated as a connection error of type `H3_FRAME_UNEXPECTED`.
+
 ## Semantics
 
 Upon receiving an `UNBOUND_DATA` frame on a request or response stream, the receiver enters unbound mode for that stream. In unbound mode:
@@ -103,15 +107,6 @@ Upon receiving an `UNBOUND_DATA` frame on a request or response stream, the rece
 - No further HTTP/3 frames (including `DATA`, `HEADERS`, or any extension frames) can be received on the stream.
 - The end of the data is indicated by the QUIC FIN on the stream.
 - If a `Content-Length` header was included, the recipient needs to ensure that the combined length of all received data (in both `DATA` and `UNBOUND_DATA` frames) matches the content length from the header.
-
-## Restrictions
-
-The use of `UNBOUND_DATA` is subject to the following restrictions:
-
-- `UNBOUND_DATA` frame is only valid on request or response streams. It is invalid on control streams, QPACK encoder/decoder streams, or push streams.
-- `UNBOUND_DATA` MUST NOT be sent to peers that have not advertised `SETTINGS_ENABLE_UNBOUND_DATA` with a value of 1.
-
-Any violation of these restrictions MUST be treated as a connection error of type `H3_FRAME_UNEXPECTED`.
 
 # Stream State Transitions
 

--- a/draft-rosomakho-httpbis-h3-unbound-data.md
+++ b/draft-rosomakho-httpbis-h3-unbound-data.md
@@ -108,7 +108,6 @@ Upon receiving an `UNBOUND_DATA` frame on a request or response stream, the rece
 
 The use of `UNBOUND_DATA` is subject to the following restrictions:
 
-- An endpoint MUST NOT send `UNBOUND_DATA` if it previously sent a `HEADERS` frame with a `Content-Length` header field.
 - `UNBOUND_DATA` frame is only valid on request or response streams. It is invalid on control streams, QPACK encoder/decoder streams, or push streams.
 - `UNBOUND_DATA` MUST NOT be sent to peers that have not advertised `SETTINGS_ENABLE_UNBOUND_DATA` with a value of 1.
 


### PR DESCRIPTION
A few changes:
* I changed the wording to move away from "forbid" / "permit" frames after UNBOUND_DATA - because it's not disallowed, it's just not possible to send them since they won't be parsed as frames
* Allowed content-length to match DATA frames
* Randomly generated the TBD values using [quic-pick](https://martinthomson.github.io/quic-pick/) so we can implement